### PR TITLE
Upgrade to helm v2.3.0, add clusterIP service for internal consumption

### DIFF
--- a/addon-templates/kubectl/helm/tiller-deploy.yaml
+++ b/addon-templates/kubectl/helm/tiller-deploy.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: "io-rancher-system"
       containers:
           - name: "tiller"
-            image: "$GCR_IO_REGISTRY/kubernetes-helm/tiller:v2.2.3"
+            image: "$GCR_IO_REGISTRY/kubernetes-helm/tiller:v2.3.0"
             imagePullPolicy: "Always"
             ports:
              - name: "tiller"

--- a/addon-templates/kubectl/helm/tiller-service.yaml
+++ b/addon-templates/kubectl/helm/tiller-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are NOT using this as an addon, you should comment out this line.
+    kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: tiller-deploy
+  name: tiller-deploy
+  namespace: kube-system
+spec:
+  ports:
+  - port: 44134
+    targetPort: 44134
+  selector:
+    app: helm
+    name: tiller


### PR DESCRIPTION
This is required for Monocular deployment features to function.