### PR TITLE
Upstream v1.6.1 dashboard

### DIFF
--- a/addon-templates/kubectl/dashboard/dashboard-controller.yaml
+++ b/addon-templates/kubectl/dashboard/dashboard-controller.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "io-rancher-system"
       containers:
       - name: kubernetes-dashboard
-        image: $DOCKER_IO_REGISTRY/rancher/kubernetes-dashboard:v0.0.1
+        image: $GCR_IO_REGISTRY/google_containers/kubernetes-dashboard-amd64:v1.6.1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
Bearer token forwarding is in this release so our fork is no longer needed.