### PR TITLE
Fix bash syntax error

### DIFF
--- a/package/entry.sh
+++ b/package/entry.sh
@@ -83,7 +83,7 @@ if [ "$1" == "kubelet" ]; then
     done
 fi
 
-if [ "$1" == "kubelet" || "$1" == "kube-proxy" ]; then
+if [ "$1" == "kubelet" ] || [ "$1" == "kube-proxy" ]; then
     FQDN=$(hostname --fqdn || hostname)
     exec "$@" --hostname-override ${FQDN}
 fi


### PR DESCRIPTION
Fixes the `NotReady` state for kubelet in rancher/rancher#9044.