### PR TITLE
Remove kube master url option from kubernetes-package

### DIFF
--- a/package/dns.sed
+++ b/package/dns.sed
@@ -1,6 +1,5 @@
 s/$DNS_SERVER_IP/10.43.0.10/g
 s/$DNS_REPLICAS/2/g
 s/$DNS_DOMAIN/cluster.local/g
-/        - --dns-port=10053/a \
-        - --kube-master-url=http://kubernetes.kubernetes:80
+/        - --dns-port=10053/a
 s/gcr.io\//\$GCR_IO_REGISTRY\//g


### PR DESCRIPTION
Remove master url option for kube-dns to automatically connect to kubernetes api over HTTPS. Fix for https://github.com/rancher/rancher/issues/9120