### PR TITLE
add ipset utility

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -9,6 +9,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get -yy -q \
     install \
+    ipset \
     iptables \
     ca-certificates \
     file \


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/15718
Ipset is used to detect if ipvs mode for kube-proxy can be activated.